### PR TITLE
Feat: 한줄평 전체조회 페이지 1차 완성

### DIFF
--- a/ReadingFrame/ReadingFrame.xcodeproj/project.pbxproj
+++ b/ReadingFrame/ReadingFrame.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		C595A2002B7BAC7A006D88EC /* RegisterBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = C595A1FF2B7BAC7A006D88EC /* RegisterBook.swift */; };
 		C595A2022B7BCB10006D88EC /* SelectBookTypeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C595A2012B7BCB10006D88EC /* SelectBookTypeView.swift */; };
 		C595A2042B7BDE87006D88EC /* DatePickerInList.swift in Sources */ = {isa = PBXBuildFile; fileRef = C595A2032B7BDE87006D88EC /* DatePickerInList.swift */; };
+		C5BAF29D2BA49F0800DC33FE /* GreyLogoAndTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BAF29C2BA49F0800DC33FE /* GreyLogoAndTextView.swift */; };
 		C5BB8B662B7CF3CE00A49858 /* SearchLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BB8B652B7CF3CE00A49858 /* SearchLocation.swift */; };
 		C5BE52252B68F53E00FF07F8 /* ReadingFrameApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BE52242B68F53E00FF07F8 /* ReadingFrameApp.swift */; };
 		C5BE52272B68F53E00FF07F8 /* LaunchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BE52262B68F53E00FF07F8 /* LaunchView.swift */; };
@@ -75,6 +76,7 @@
 		C595A1FF2B7BAC7A006D88EC /* RegisterBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterBook.swift; sourceTree = "<group>"; };
 		C595A2012B7BCB10006D88EC /* SelectBookTypeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectBookTypeView.swift; sourceTree = "<group>"; };
 		C595A2032B7BDE87006D88EC /* DatePickerInList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerInList.swift; sourceTree = "<group>"; };
+		C5BAF29C2BA49F0800DC33FE /* GreyLogoAndTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GreyLogoAndTextView.swift; sourceTree = "<group>"; };
 		C5BB8B652B7CF3CE00A49858 /* SearchLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchLocation.swift; sourceTree = "<group>"; };
 		C5BE52212B68F53E00FF07F8 /* ReadingFrame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ReadingFrame.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5BE52242B68F53E00FF07F8 /* ReadingFrameApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingFrameApp.swift; sourceTree = "<group>"; };
@@ -385,6 +387,7 @@
 				C5CEA8912B8A5CCA007A89A2 /* WrapLayout.swift */,
 				E751B5712B8EC6B000880123 /* DragIndicator.swift */,
 				E751B5732B8ED1D100880123 /* DateRange.swift */,
+				C5BAF29C2BA49F0800DC33FE /* GreyLogoAndTextView.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -474,6 +477,7 @@
 				E716315F2B7C982600BCD302 /* MainPageBookItem.swift in Sources */,
 				E71631612B7CD08B00BCD302 /* MainPageWantToReadBookRow.swift in Sources */,
 				E702A9B02B86219C0081F65D /* PageIndicator.swift in Sources */,
+				C5BAF29D2BA49F0800DC33FE /* GreyLogoAndTextView.swift in Sources */,
 				E7A0DD2E2B7B617E006004B5 /* SearchView.swift in Sources */,
 				C5338FA42B8DD76900D24B5F /* CommentReactionToken.swift in Sources */,
 				C51C1DD12B83E7B500B45345 /* CommentHScrollView.swift in Sources */,

--- a/ReadingFrame/ReadingFrame/BookInfo/Helpers/CommentHScrollView.swift
+++ b/ReadingFrame/ReadingFrame/BookInfo/Helpers/CommentHScrollView.swift
@@ -20,6 +20,8 @@ struct CommentHScrollView: View {
                     singleCommentBox(comment: comment)
                 }
             }
+            // BookInfo 다른 아이템들과 여백 동일하게 보이기 위해 적용(처음 한줄평의 leading과 마지막 한줄평 trailing)
+            .padding(.horizontal, 16)
         }
         // 좌우 스크롤 안보이게 하기(미관상 이게 더 예쁜 것 같음)
         .scrollIndicators(.hidden)

--- a/ReadingFrame/ReadingFrame/BookInfo/Helpers/CommentRowView.swift
+++ b/ReadingFrame/ReadingFrame/BookInfo/Helpers/CommentRowView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 /// 한줄평 List Row
 struct CommentRowView: View {
+    // MARK: - Property
+    
     /// API 호출해서 BookInfo_Review 페이지에서 받아올 한줄평 정보
     @Bindable var comment: Comment
     
@@ -24,17 +26,74 @@ struct CommentRowView: View {
         return dateString
     }
     
+    /// 이 row의 리뷰가 유저의 리뷰인지 확인하고 더보기 버튼 대신 삭제 버튼을 띄워줄 값
+    var isMyReview: Bool {
+        // TODO: 내 닉네임과 comment 닉네임이 일치하는지 검사
+        // 지금은 일단 dummy로 독서왕으로 설정
+        if (comment.nickname == "독서왕") {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    // MARK: - Body
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
-            // MARK: 닉네임
-            Text(comment.nickname)
-                .font(.subheadline.weight(.bold))
-            
-            // MARK: 날짜
-            Text(dateString)
-                .font(.footnote)
-                .foregroundStyle(.greyText)
-                .padding(.bottom, 9)
+            // 닉네임, 날짜, 메뉴 버튼
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 3) {
+                    // MARK: 닉네임
+                    Text(comment.nickname)
+                        .font(.subheadline.weight(.bold))
+                    
+                    // MARK: 날짜
+                    Text(dateString)
+                        .font(.footnote)
+                        .foregroundStyle(.greyText)
+                        .padding(.bottom, 9)
+                }
+                
+                Spacer()
+                
+                // MARK: 메뉴 or 삭제 버튼
+                if isMyReview {
+                    // 내가 쓴 리뷰라면 삭제 '버튼' 보여주기
+                    Button(action: {
+                        print("내가 쓴 한줄평 삭제")
+                        // TODO: 삭제하시겠습니까 알람창 띄워주기
+                    }) {
+                        Image(systemName: "xmark")
+                            .font(.body)
+                            .foregroundStyle(.black0)
+                    }
+                } else {
+                    // 내가 쓴 리뷰가 아니라면 신고 메뉴 보여주기
+                    Menu {
+                        Menu("신고하기") {
+                            Button("부적절한 리뷰", action: {
+                                print("부적절한 리뷰입니다.")
+                                // TODO: 신고 알람창 띄우기
+                                
+                                // 신고하겠다는 확인 들어오면
+                                // TODO: 신고하기 API 호출하기 reportType: 0
+                            })
+                            Button("스팸/도배성 리뷰", action: {
+                                print("스팸/도배성 리뷰입니다.")
+                                // TODO: 신고 알람창 띄우기
+                                
+                                // 신고하겠다는 확인 들어오면
+                                // TODO: 신고하기 API 호출하기 reportType: 1
+                            })
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .font(.body)
+                            .foregroundStyle(.black0)
+                    }
+                    
+                }
+            }
             
             // MARK: 한줄평 텍스트
             Text(comment.commentText)

--- a/ReadingFrame/ReadingFrame/BookInfo/Helpers/CommentRowView.swift
+++ b/ReadingFrame/ReadingFrame/BookInfo/Helpers/CommentRowView.swift
@@ -86,7 +86,7 @@ struct CommentRowView: View {
                         self.showReviewDeleteAlert.toggle()
                     }
                     
-                    // 버튼 눌렀을 때 띄워줄 alert
+                    // 삭제 버튼 눌렀을 때 띄워줄 alert
                     .alert(isPresented: $showReviewDeleteAlert) {
                         /// 리뷰 삭제하시겠습니까 alert의 "예" 버튼
                         let doDeleteButton = Alert.Button.destructive(Text("예")) {
@@ -110,31 +110,64 @@ struct CommentRowView: View {
                         // > 신고하기
                         Menu("신고하기") {
                             // 세부 메뉴 1: 부적절한 리뷰
-                            Button("부적절한 리뷰", action: {
+                            Button("부적절한 리뷰") {
                                 print("부적절한 리뷰입니다.")
-                                // TODO: 신고 알람창 띄우기
                                 
-                                // 신고하겠다는 확인 들어오면
-                                // TODO: 신고하기 API 호출하기 reportType: 0
-                            })
+                                // 신고 알람창 띄우기
+                                self.showInappropriateComplaintAlert.toggle()
+                            }
+                            
                             
                             // 세부 메뉴 2: 스팸/도배성 리뷰
-                            Button("스팸/도배성 리뷰", action: {
+                            Button("스팸/도배성 리뷰") {
                                 print("스팸/도배성 리뷰입니다.")
-                                // TODO: 신고 알람창 띄우기
                                 
-                                // 신고하겠다는 확인 들어오면
-                                // TODO: 신고하기 API 호출하기 reportType: 1
-                            })
+                                // 신고 알람창 띄우기
+                                self.showSpamComplaintAlert.toggle()
+                            }
                         }
                     } label: {
                         Image(systemName: "ellipsis")
                             .font(.body)
                             .foregroundStyle(.black0)
                     }
-                    
                 }
-            }
+                
+                // 부적절한 리뷰로 신고하기 alert
+                ZStack {}
+                    .alert(isPresented: $showInappropriateComplaintAlert) {
+                        // 부적절한 리뷰로 신고하기 '예' 버튼
+                        let reportComplaintButton = Alert.Button.destructive(Text("예")) {
+                            // 신고하겠다는 확인 들어오면
+                            // TODO: 신고하기 API 호출하기 reportType: 0
+                            
+                            print("부적절한 리뷰로 신고")
+                        }
+                        
+                        return Alert(title: Text("해당 리뷰를 부적절한 리뷰로 신고하시겠습니까?"),
+                                     message: Text("허위 신고 시 불이익을 받을 수 있습니다."),
+                                     primaryButton: .default(Text("아니요")),
+                                     secondaryButton: reportComplaintButton)
+                    }
+                
+                // 스팸/도배성 리뷰로 신고하기 alert
+                ZStack {}
+                    .alert(isPresented: $showSpamComplaintAlert) {
+                        
+                        // 부적절한 리뷰로 신고하기 '예' 버튼
+                        let reportComplaintButton = Alert.Button.destructive(Text("예")) {
+                            // 신고하겠다는 확인 들어오면
+                            // TODO: 신고하기 API 호출하기 reportType: 1
+                            
+                            print("스팸/도배성 리뷰로 신고")
+                        }
+                        
+                        return Alert(title: Text("해당 리뷰를 스팸/도배성 리뷰로 신고하시겠습니까?"),
+                                     message: Text("허위 신고 시 불이익을 받을 수 있습니다."),
+                                     primaryButton: .default(Text("아니요")),
+                                     secondaryButton: reportComplaintButton)
+                    }
+            } // HStack 끝
             
             // MARK: 한줄평 텍스트
             Text(comment.commentText)

--- a/ReadingFrame/ReadingFrame/BookInfo/Views/BookInfo.swift
+++ b/ReadingFrame/ReadingFrame/BookInfo/Views/BookInfo.swift
@@ -87,7 +87,10 @@ struct BookInfo: View {
                         } else {
                             // 한줄평 가로스크롤뷰
                             CommentHScrollView(comments: comments)
+                            // 내서재 추가하기 버튼 위로까지 컨텐츠 보여주기
                                 .padding(.bottom, 120)
+                            // 화면상 뜨는 공간 없이 가로스크롤
+                                .padding(.horizontal, -16)
                         }
                         
                     }

--- a/ReadingFrame/ReadingFrame/BookInfo/Views/BookInfo_Review.swift
+++ b/ReadingFrame/ReadingFrame/BookInfo/Views/BookInfo_Review.swift
@@ -27,7 +27,8 @@ struct BookInfo_Review: View {
     
     /// 한줄평 데이터들
     var comments: [Comment] {
-        return modelData.comments
+        // 임시변수 isVisible 변수가 true인 한줄평만 보여주기
+        return modelData.comments.filter { $0.isVisible }
     }
 
     
@@ -44,8 +45,10 @@ struct BookInfo_Review: View {
     
             // MARK: 한줄평 리스트
             List(comments) { comment in
-                // TODO: 한줄평 하나 표시할 Row마다 View 만들어서 List로 보여주기
+                // 한줄평 하나 표시할 Row마다 View 만들어서 List로 보여주기
                 CommentRowView(comment: comment)
+                    // 유저가 한줄평 삭제했을 때 애니메이션 효과 적용되면서 리스트에서 사라지도록
+                    .animation(.easeOut, value: comment.isVisible)
             }
             .listStyle(.plain)
         }        

--- a/ReadingFrame/ReadingFrame/BookInfo/Views/BookInfo_Review.swift
+++ b/ReadingFrame/ReadingFrame/BookInfo/Views/BookInfo_Review.swift
@@ -11,8 +11,8 @@ import SwiftUI
 struct BookInfo_Review: View {
     // MARK: - Property
     /// API 통해서 받아올 한줄평 데이터들. 지금은 일단 더미 데이터로 입력해두었습니다.
-    @State var modelData = BookInfo_ReviewModel(comments:
-                                                    [Comment(commentText: "베스트셀러인 이유가 있는 것 같아요. 한 번쯤 읽어 보시기를 추천합니다!", nickname: "시나모롤", heartCount: 2, goodCount: 5),
+    @State var modelData = BookInfo_ReviewModel(comments: /*[]*/
+                                                     [Comment(commentText: "베스트셀러인 이유가 있는 것 같아요. 한 번쯤 읽어 보시기를 추천합니다!", nickname: "시나모롤", heartCount: 2, goodCount: 5),
                                                      Comment(commentText: "3번째 읽고 있습니다. 읽을 때마다 감동이 오는 것 같아요! 같은 책을 여러 번 읽는 건 처음이네요. 인생 책을 만난 기분입니다!", nickname: "독서왕", heartCount: 2, goodCount: 5),
                                                      Comment(commentText: "흠.. 저는 기대했던 것 보다는 별로였던 것 같아요.", nickname: "비니", goodCount: 1, wowCount: 2, sadCount: 5, angryCount: 2),
                                                      Comment(commentText: "베스트셀러인 이유가 있는 것 같아요. 한 번쯤 읽어 보시기를 추천합니다!", nickname: "시나모롤", heartCount: 2, goodCount: 5),
@@ -39,19 +39,27 @@ struct BookInfo_Review: View {
             // MARK: 반응순 최신순 버튼
             HStack {
                 Spacer()
-                sortTypeView(orderType: $orderType)
+                SortTypeView(orderType: $orderType)
             }
             .padding([.top, .horizontal], 16)
-    
+            
             // MARK: 한줄평 리스트
-            List(comments) { comment in
-                // 한줄평 하나 표시할 Row마다 View 만들어서 List로 보여주기
-                CommentRowView(comment: comment)
-                    // 유저가 한줄평 삭제했을 때 애니메이션 효과 적용되면서 리스트에서 사라지도록
-                    .animation(.easeOut, value: comment.isVisible)
+            // 한줄평이 없다면 작성된 리뷰 없다는 화면 보여주기
+            if (self.comments.isEmpty) {
+                GreyLogoAndTextView(text: "아직 작성된 리뷰가 없어요")
             }
-            .listStyle(.plain)
-        }        
+            // 한줄평이 있다면 한줄평 리스트 보여주기
+            else {
+                List(comments) { comment in
+                    // 한줄평 하나 표시할 Row마다 View 만들어서 List로 보여주기
+                    CommentRowView(comment: comment)
+                    // 유저가 한줄평 삭제했을 때 애니메이션 효과 적용되면서 리스트에서 사라지도록
+                        .animation(.easeOut, value: comment.isVisible)
+                }
+                .listStyle(.plain)
+                
+            }
+        }
         // MARK: 네비게이션 바 설정
         .navigationTitle("독자들의 한줄평")
         .navigationBarTitleDisplayMode(.inline)
@@ -60,7 +68,7 @@ struct BookInfo_Review: View {
 }
 
 /// 반응순/최신순 선택하기 버튼
-struct sortTypeView: View {
+struct SortTypeView: View {
     
     /// 정렬방식 받아와서 바꿔주기
     @Binding var orderType: OrderType

--- a/ReadingFrame/ReadingFrame/Common/Helpers/GreyLogoAndTextView.swift
+++ b/ReadingFrame/ReadingFrame/Common/Helpers/GreyLogoAndTextView.swift
@@ -1,0 +1,33 @@
+//
+//  GreyLogoAndTextView.swift
+//  ReadingFrame
+//
+//  Created by 석민솔 on 3/16/24.
+//
+
+import SwiftUI
+
+/// 데이터가 없을 때 안내 메시지와 로고를 회색으로 보여주는 공통 화면
+struct GreyLogoAndTextView: View {
+    var text: String
+    
+    var body: some View {
+        VStack(alignment: .center, spacing: 25) {
+            Spacer()
+            
+            Image("character_main")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 90, height: 120)
+            
+            Text(text)
+                .foregroundStyle(Color.greyText)
+            
+            Spacer()
+        }
+    }
+}
+
+#Preview {
+    GreyLogoAndTextView(text: "아직 뭐가 없어요")
+}

--- a/ReadingFrame/ReadingFrame/Common/Models/Review.swift
+++ b/ReadingFrame/ReadingFrame/Common/Models/Review.swift
@@ -45,6 +45,10 @@ class Comment: Identifiable, Hashable {
     var sadCount: Int
     var angryCount: Int
     
+    /// 임시변수 UI용) 유저가 한줄평을 삭제(하거나 신고)했을 때 해당 한줄평이 리스트 페이지에서 안보이도록
+    /// API에 반영하면서 화면에서도 바로 삭제되는 것 보여주도록
+    var isVisible: Bool = true
+    
     // MARK: Initializer
     init(commentText: String = "저는 이 책을 읽기 위해 태어났습니다",
          nickname: String = "사용자",

--- a/ReadingFrame/ReadingFrame/Search/Views/SearchView.swift
+++ b/ReadingFrame/ReadingFrame/Search/Views/SearchView.swift
@@ -42,22 +42,7 @@ struct searchResults: View {
     var body: some View {
         // 검색어를 안 입력했다면
         if (searchText.isEmpty) {
-            Spacer()
-            
-            VStack {
-                Image("character_main")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 89)
-                
-                Text("찾고 있는 책을 검색해 보세요.")
-                    .foregroundStyle(.greyText)
-                    .padding(.top, 25)
-            }
-            .padding(.bottom, 176)
-            
-            Spacer()
-            
+            GreyLogoAndTextView(text: "찾고 있는 책을 검색해 보세요.")            
         }
         // 검색어를 입력했다면
         else {


### PR DESCRIPTION
- 도서정보에서 한줄평 가로 스크롤 부분에 적용되는 여백 없애도록 수정 
- 한줄평 row 우측상단 버튼 모양: 유저 본인의 한줄평이 있을 경우 삭제 버튼으로 보여주고, 다른 유저 한줄평일 경우 더보기 버튼으로 보여주기
- 삭제 버튼, 신고 버튼과 연결되는 alert 구현
- `GreyLogoAndTextView`: 로고와 간단한 문구 보여주는 화면
    - 한줄평 없을 시 아직 작성된 리뷰가 없다는 안내문구 화면 보여주기
    - 검색 화면에도 코드 대신 View 생성