### PR TITLE
Feat: 홈 화면의 책 상세 화면 리스트 구현

### DIFF
--- a/ReadingFrame/ReadingFrame.xcodeproj/project.pbxproj
+++ b/ReadingFrame/ReadingFrame.xcodeproj/project.pbxproj
@@ -36,16 +36,16 @@
 		C5CEA8942B8A66D8007A89A2 /* BookInfo_Review.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5CEA8932B8A66D8007A89A2 /* BookInfo_Review.swift */; };
 		C5DF2B842B7F8E740069B64D /* BookInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5DF2B832B7F8E740069B64D /* BookInfo.swift */; };
 		C5DF2B862B7FC94D0069B64D /* Badge_Info.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5DF2B852B7FC94D0069B64D /* Badge_Info.swift */; };
-		E702A9A82B85CAF50081F65D /* MainPageReadingBookItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = E702A9A72B85CAF50081F65D /* MainPageReadingBookItem.swift */; };
+		E702A9A82B85CAF50081F65D /* ReadingItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E702A9A72B85CAF50081F65D /* ReadingItemView.swift */; };
 		E702A9AA2B85F0ED0081F65D /* ReadingPercentBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E702A9A92B85F0ED0081F65D /* ReadingPercentBar.swift */; };
 		E702A9AC2B85FB2F0081F65D /* ReadingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E702A9AB2B85FB2F0081F65D /* ReadingLabel.swift */; };
-		E702A9AE2B8605D10081F65D /* MainPageReadingBookRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E702A9AD2B8605D10081F65D /* MainPageReadingBookRow.swift */; };
+		E702A9AE2B8605D10081F65D /* ReadingRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E702A9AD2B8605D10081F65D /* ReadingRowView.swift */; };
 		E702A9B02B86219C0081F65D /* PageIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E702A9AF2B86219C0081F65D /* PageIndicator.swift */; };
 		E702A9B42B864D330081F65D /* ReadingNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = E702A9B32B864D330081F65D /* ReadingNote.swift */; };
-		E716315F2B7C982600BCD302 /* MainPageBookItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = E716315E2B7C982600BCD302 /* MainPageBookItem.swift */; };
-		E71631612B7CD08B00BCD302 /* MainPageWantToReadBookRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71631602B7CD08B00BCD302 /* MainPageWantToReadBookRow.swift */; };
+		E716315F2B7C982600BCD302 /* BookItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E716315E2B7C982600BCD302 /* BookItemView.swift */; };
+		E71631612B7CD08B00BCD302 /* WantToReadRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71631602B7CD08B00BCD302 /* WantToReadRowView.swift */; };
 		E71631632B7CF1A900BCD302 /* LoadableBookImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71631622B7CF1A900BCD302 /* LoadableBookImage.swift */; };
-		E751B56E2B8E0D3100880123 /* MainPageFinishReadBookRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E751B56D2B8E0D3100880123 /* MainPageFinishReadBookRow.swift */; };
+		E751B56E2B8E0D3100880123 /* FinishReadRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E751B56D2B8E0D3100880123 /* FinishReadRowView.swift */; };
 		E751B5702B8EC61A00880123 /* EditBookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = E751B56F2B8EC61A00880123 /* EditBookmark.swift */; };
 		E751B5722B8EC6B000880123 /* DragIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E751B5712B8EC6B000880123 /* DragIndicator.swift */; };
 		E751B5742B8ED1D100880123 /* DateRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = E751B5732B8ED1D100880123 /* DateRange.swift */; };
@@ -89,16 +89,16 @@
 		C5CEA8932B8A66D8007A89A2 /* BookInfo_Review.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookInfo_Review.swift; sourceTree = "<group>"; };
 		C5DF2B832B7F8E740069B64D /* BookInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookInfo.swift; sourceTree = "<group>"; };
 		C5DF2B852B7FC94D0069B64D /* Badge_Info.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Badge_Info.swift; sourceTree = "<group>"; };
-		E702A9A72B85CAF50081F65D /* MainPageReadingBookItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageReadingBookItem.swift; sourceTree = "<group>"; };
+		E702A9A72B85CAF50081F65D /* ReadingItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingItemView.swift; sourceTree = "<group>"; };
 		E702A9A92B85F0ED0081F65D /* ReadingPercentBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingPercentBar.swift; sourceTree = "<group>"; };
 		E702A9AB2B85FB2F0081F65D /* ReadingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingLabel.swift; sourceTree = "<group>"; };
-		E702A9AD2B8605D10081F65D /* MainPageReadingBookRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageReadingBookRow.swift; sourceTree = "<group>"; };
+		E702A9AD2B8605D10081F65D /* ReadingRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingRowView.swift; sourceTree = "<group>"; };
 		E702A9AF2B86219C0081F65D /* PageIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageIndicator.swift; sourceTree = "<group>"; };
 		E702A9B32B864D330081F65D /* ReadingNote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingNote.swift; sourceTree = "<group>"; };
-		E716315E2B7C982600BCD302 /* MainPageBookItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageBookItem.swift; sourceTree = "<group>"; };
-		E71631602B7CD08B00BCD302 /* MainPageWantToReadBookRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageWantToReadBookRow.swift; sourceTree = "<group>"; };
+		E716315E2B7C982600BCD302 /* BookItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookItemView.swift; sourceTree = "<group>"; };
+		E71631602B7CD08B00BCD302 /* WantToReadRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WantToReadRowView.swift; sourceTree = "<group>"; };
 		E71631622B7CF1A900BCD302 /* LoadableBookImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadableBookImage.swift; sourceTree = "<group>"; };
-		E751B56D2B8E0D3100880123 /* MainPageFinishReadBookRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageFinishReadBookRow.swift; sourceTree = "<group>"; };
+		E751B56D2B8E0D3100880123 /* FinishReadRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishReadRowView.swift; sourceTree = "<group>"; };
 		E751B56F2B8EC61A00880123 /* EditBookmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditBookmark.swift; sourceTree = "<group>"; };
 		E751B5712B8EC6B000880123 /* DragIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragIndicator.swift; sourceTree = "<group>"; };
 		E751B5732B8ED1D100880123 /* DateRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRange.swift; sourceTree = "<group>"; };
@@ -348,11 +348,11 @@
 		E716315D2B7C980500BCD302 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
-				E702A9A72B85CAF50081F65D /* MainPageReadingBookItem.swift */,
-				E702A9AD2B8605D10081F65D /* MainPageReadingBookRow.swift */,
-				E716315E2B7C982600BCD302 /* MainPageBookItem.swift */,
-				E71631602B7CD08B00BCD302 /* MainPageWantToReadBookRow.swift */,
-				E751B56D2B8E0D3100880123 /* MainPageFinishReadBookRow.swift */,
+				E702A9A72B85CAF50081F65D /* ReadingItemView.swift */,
+				E702A9AD2B8605D10081F65D /* ReadingRowView.swift */,
+				E716315E2B7C982600BCD302 /* BookItemView.swift */,
+				E71631602B7CD08B00BCD302 /* WantToReadRowView.swift */,
+				E751B56D2B8E0D3100880123 /* FinishReadRowView.swift */,
 				E702A9AB2B85FB2F0081F65D /* ReadingLabel.swift */,
 				E702A9AF2B86219C0081F65D /* PageIndicator.swift */,
 			);
@@ -473,9 +473,9 @@
 				E7A0DD302B7B6B5B006004B5 /* HomeSegmentedControl.swift in Sources */,
 				E702A9AC2B85FB2F0081F65D /* ReadingLabel.swift in Sources */,
 				E751B5722B8EC6B000880123 /* DragIndicator.swift in Sources */,
-				E751B56E2B8E0D3100880123 /* MainPageFinishReadBookRow.swift in Sources */,
-				E716315F2B7C982600BCD302 /* MainPageBookItem.swift in Sources */,
-				E71631612B7CD08B00BCD302 /* MainPageWantToReadBookRow.swift in Sources */,
+				E751B56E2B8E0D3100880123 /* FinishReadRowView.swift in Sources */,
+				E716315F2B7C982600BCD302 /* BookItemView.swift in Sources */,
+				E71631612B7CD08B00BCD302 /* WantToReadRowView.swift in Sources */,
 				E702A9B02B86219C0081F65D /* PageIndicator.swift in Sources */,
 				C5BAF29D2BA49F0800DC33FE /* GreyLogoAndTextView.swift in Sources */,
 				E7A0DD2E2B7B617E006004B5 /* SearchView.swift in Sources */,
@@ -492,7 +492,7 @@
 				C595A1E82B7A9FFB006D88EC /* BookMap.swift in Sources */,
 				C51556C32B830402006FD0F2 /* BookInfoBottomButtonView.swift in Sources */,
 				C595A1DE2B7A9DD6006D88EC /* AppTabView.swift in Sources */,
-				E702A9AE2B8605D10081F65D /* MainPageReadingBookRow.swift in Sources */,
+				E702A9AE2B8605D10081F65D /* ReadingRowView.swift in Sources */,
 				E71631632B7CF1A900BCD302 /* LoadableBookImage.swift in Sources */,
 				E751B5742B8ED1D100880123 /* DateRange.swift in Sources */,
 				C5338FA82B8E1B1600D24B5F /* CommentRowView.swift in Sources */,
@@ -506,7 +506,7 @@
 				C5DF2B842B7F8E740069B64D /* BookInfo.swift in Sources */,
 				C51556C62B839367006FD0F2 /* BookInfoModel.swift in Sources */,
 				E751B5702B8EC61A00880123 /* EditBookmark.swift in Sources */,
-				E702A9A82B85CAF50081F65D /* MainPageReadingBookItem.swift in Sources */,
+				E702A9A82B85CAF50081F65D /* ReadingItemView.swift in Sources */,
 				C595A1E02B7A9E59006D88EC /* MainPage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ReadingFrame/ReadingFrame.xcodeproj/project.pbxproj
+++ b/ReadingFrame/ReadingFrame.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		E7A0DD2C2B7B52A7006004B5 /* Fonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A0DD2B2B7B52A7006004B5 /* Fonts.swift */; };
 		E7A0DD2E2B7B617E006004B5 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A0DD2D2B7B617E006004B5 /* SearchView.swift */; };
 		E7A0DD302B7B6B5B006004B5 /* HomeSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A0DD2F2B7B6B5B006004B5 /* HomeSegmentedControl.swift */; };
+		E7F6D81C2BA6D8C000181586 /* ReadingItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F6D81B2BA6D8C000181586 /* ReadingItemDetailView.swift */; };
+		E7F6D81E2BA6D92E00181586 /* BookRowDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F6D81D2BA6D92E00181586 /* BookRowDetailView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -107,6 +109,8 @@
 		E7A0DD2B2B7B52A7006004B5 /* Fonts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fonts.swift; sourceTree = "<group>"; };
 		E7A0DD2D2B7B617E006004B5 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		E7A0DD2F2B7B6B5B006004B5 /* HomeSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSegmentedControl.swift; sourceTree = "<group>"; };
+		E7F6D81B2BA6D8C000181586 /* ReadingItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingItemDetailView.swift; sourceTree = "<group>"; };
+		E7F6D81D2BA6D92E00181586 /* BookRowDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookRowDetailView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -353,6 +357,8 @@
 				E716315E2B7C982600BCD302 /* BookItemView.swift */,
 				E71631602B7CD08B00BCD302 /* WantToReadRowView.swift */,
 				E751B56D2B8E0D3100880123 /* FinishReadRowView.swift */,
+				E7F6D81B2BA6D8C000181586 /* ReadingItemDetailView.swift */,
+				E7F6D81D2BA6D92E00181586 /* BookRowDetailView.swift */,
 				E702A9AB2B85FB2F0081F65D /* ReadingLabel.swift */,
 				E702A9AF2B86219C0081F65D /* PageIndicator.swift */,
 			);
@@ -468,12 +474,14 @@
 				C5CEA8922B8A5CCA007A89A2 /* WrapLayout.swift in Sources */,
 				C518A8AB2B8132F800EBD1A8 /* Review.swift in Sources */,
 				E7A0DD2C2B7B52A7006004B5 /* Fonts.swift in Sources */,
+				E7F6D81C2BA6D8C000181586 /* ReadingItemDetailView.swift in Sources */,
 				C58F57192B8D001F004085A5 /* CommentReactionView.swift in Sources */,
 				E702A9B42B864D330081F65D /* ReadingNote.swift in Sources */,
 				E7A0DD302B7B6B5B006004B5 /* HomeSegmentedControl.swift in Sources */,
 				E702A9AC2B85FB2F0081F65D /* ReadingLabel.swift in Sources */,
 				E751B5722B8EC6B000880123 /* DragIndicator.swift in Sources */,
 				E751B56E2B8E0D3100880123 /* FinishReadRowView.swift in Sources */,
+				E7F6D81E2BA6D92E00181586 /* BookRowDetailView.swift in Sources */,
 				E716315F2B7C982600BCD302 /* BookItemView.swift in Sources */,
 				E71631612B7CD08B00BCD302 /* WantToReadRowView.swift in Sources */,
 				E702A9B02B86219C0081F65D /* PageIndicator.swift in Sources */,

--- a/ReadingFrame/ReadingFrame/Common/Helpers/ReadingPercentBar.swift
+++ b/ReadingFrame/ReadingFrame/Common/Helpers/ReadingPercentBar.swift
@@ -12,41 +12,41 @@ struct ReadingPercentBar: View {
     /// 책 객제
     @Bindable var book: RegisteredBook
     
-    /// 막대 그래프 너비
-    var width: Int = 0
-    
     var body: some View {
         // MARK: 막대 그래프
-        ZStack(alignment: .leading) {
-            // 배경
-            RoundedRectangle(cornerRadius: 10)
-                .frame(width: CGFloat(width), height: 9)
-                .foregroundStyle(.grey2)
-                .opacity(0.25)
-            
-            // 퍼센트
-            RoundedRectangle(cornerRadius: 10)
-                .frame(width: floor(Double(book.readingPercent)) * Double((width / 100)), height: 9)
+        GeometryReader { geometry in
+            VStack(spacing: 0) {
+                ZStack(alignment: .leading) {
+                    // 배경
+                    RoundedRectangle(cornerRadius: 10)
+                        .frame(width: geometry.size.width, height: 9)
+                        .foregroundStyle(.grey2)
+                        .opacity(0.25)
+                    
+                    // 퍼센트
+                    RoundedRectangle(cornerRadius: 10)
+                        .frame(width: CGFloat(floor(Double(book.readingPercent)) / 100 * Double(geometry.size.width)), height: 9)
+                        .foregroundStyle(.black0)
+                }
+                .padding(.top, 19)
+                
+                HStack(spacing: 0) {
+                    // MARK: 읽은 퍼센트
+                    Text("\(String(format: "%d", book.readingPercent))%")
+                        .font(.caption)
+                    
+                    Spacer()
+                    
+                    // MARK: 읽은 페이지와 전체 페이지
+                    Text("\(String(format: "%d", book.readPage))/")
+                        .font(.caption)
+                    Text("\(String(format: "%d", book.book.totalPage))")
+                        .font(.caption)
+                }
                 .foregroundStyle(.black0)
+                .padding(.top, 6)
+            }
         }
-        .padding(.top, 19)
-        
-        HStack(spacing: 0) {
-            // MARK: 읽은 퍼센트
-            Text("\(String(format: "%d", book.readingPercent))%")
-                .font(.caption)
-            
-            Spacer()
-            
-            // MARK: 읽은 페이지와 전체 페이지
-            Text("\(String(format: "%d", book.readPage))/")
-                .font(.caption)
-            Text("\(String(format: "%d", book.book.totalPage))")
-                .font(.caption)
-        }
-        .foregroundStyle(.black0)
-        .frame(width: CGFloat(width))
-        .padding(.top, 6)
     }
 }
 

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/BookItemView.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/BookItemView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 /// 홈 화면의 읽고 싶은 책, 다 읽은 책 리스트에 들어가는 개별 뷰
-struct MainPageBookItem: View {
+struct BookItemView: View {
     
     /// 책 객체
     @Bindable var book: RegisteredBook
@@ -161,5 +161,5 @@ struct MainPageBookItem: View {
 }
 
 #Preview {
-    MainPageBookItem(book: RegisteredBook())
+    BookItemView(book: RegisteredBook())
 }

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/BookRowDetailView.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/BookRowDetailView.swift
@@ -1,0 +1,91 @@
+//
+//  BookRowDetailView.swift
+//  ReadingFrame
+//
+//  Created by 이윤지 on 3/17/24.
+//
+
+import SwiftUI
+
+/// 읽고 있는 책, 읽고 싶은 책, 다 읽은 책 상세 페이지의 리스트 뷰
+struct BookRowDetailView: View {
+    var readingStatus: ReadingStatus // 독서 상태 여부
+    @State var bookList: [RegisteredBook] // 각 책 리스트(추후 api연동 시 삭제될 변수)
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // MARK: 검색 바
+            NavigationLink {
+                // 검색 바 클릭 시 검색 화면으로 이동
+                SearchView()
+                    .toolbarRole(.editor) // back 텍스트 표시X
+            } label: {
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                    
+                    Text("제목, 작가를 입력하세요")
+                    
+                    Spacer()
+                }
+                .padding(EdgeInsets(top: 8, leading: 7, bottom: 8, trailing: 7))
+                .foregroundStyle(.greyText)
+                .background(Color(.grey1))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+            }
+            .padding([.leading, .trailing], 16)
+            
+            // MARK: 타이틀 및 책 개수
+            HStack {
+                title()
+                    .font(.thirdTitle)
+                    .foregroundStyle(.black0)
+                
+                Text("\(bookList.count)")
+                    .font(.thirdTitle)
+                    .foregroundStyle(.black0)
+                
+                Spacer()
+            }
+            .padding([.leading, .trailing], 16)
+            .padding(.top, 19)
+            
+            // MARK: 책 리스트
+            List {
+                ForEach(bookList) { book in
+                    // 읽고 있는 책 리스트로 띄우기
+                    ReadingItemDetailView(book: book)
+                        .listRowSeparator(.hidden) // list 구분선 제거
+                        .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                }
+                .onDelete(perform: delete)
+            }
+            .listStyle(.plain)
+            .padding(.top, 15)
+        }
+        // MARK: 네비게이션 타이틀 바
+        .navigationTitle(title())
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    // 네비게이션 바 제목 설정하는 함수
+    func title() -> Text {
+        if (readingStatus == .reading) {
+            return Text("읽고 있는 책")
+        }
+        else if (readingStatus == .wantToRead) {
+            return Text("읽고 싶은 책")
+        }
+        else {
+            return Text("다 읽은 책")
+        }
+    }
+    
+    // 리스트 책 아이템 삭제 함수
+    func delete(indexSet: IndexSet) {
+        bookList.remove(atOffsets: indexSet)
+    }
+}
+
+#Preview {
+    BookRowDetailView(readingStatus: .reading, bookList: [RegisteredBook(), RegisteredBook(), RegisteredBook()])
+}

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/FinishReadRowView.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/FinishReadRowView.swift
@@ -1,31 +1,31 @@
 //
-//  MainPageBookRow.swift
+//  FinishReadBookRow.swift
 //  ReadingFrame
 //
-//  Created by 이윤지 on 2/14/24.
+//  Created by 이윤지 on 2/27/24.
 //
 
 import SwiftUI
 
-/// 홈 화면의 읽고 싶은 책 리스트
-struct MainPageWantToReadBookRow: View {
+/// 홈 화면의 다 읽은 책 리스트
+struct FinishReadRowView: View {
     
-    /// 읽고 싶은 책 리스트
-    var wantToReadBooksList: [RegisteredBook]
+    /// 다 읽은 책 리스트
+    var finishReadBooksList: [RegisteredBook]
     
-    /// 읽고 싶은 책 총 개수
-    //var totalWantToReadBooksCount: Int = 0
+    /// 그리드 아이템
+    var columns: [GridItem] = Array(repeating: .init(.flexible()), count: 2)
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
-                Text("읽고 싶은 책 \(wantToReadBooksList.count)")
+                Text("다 읽은 책 \(finishReadBooksList.count)")
                     .font(.thirdTitle)
                     .foregroundStyle(.black0)
                 
                 Spacer()
                 
-                // MARK: 읽고 싶은 책 상세 페이지로 이동
+                // MARK: 다 읽은 책 상세 페이지로 이동
                 Button {
                     
                 } label: {
@@ -39,21 +39,21 @@ struct MainPageWantToReadBookRow: View {
             .padding(.bottom, 16)
             
             // 세로 스크롤 뷰
-            ScrollView(.horizontal, showsIndicators: false) {
-                LazyHStack {
-                    ForEach(Array(wantToReadBooksList.prefix(10)), id: \.id) { book in
+            ScrollView(showsIndicators: false) {
+                LazyVGrid(columns: columns) {
+                    ForEach(Array(finishReadBooksList.enumerated()), id: \.offset) { index, book in
                         // 읽고 싶은 책만 리스트로 띄우기
-                        MainPageBookItem(book: book)
+                        BookItemView(book: book)
                     }
                 }
                 .padding(.leading, 16)
                 .padding(.trailing, 4)
             }
         }
-        .padding(.bottom, 35)
+        .padding(.bottom, 55)
     }
 }
 
 #Preview {
-    MainPageWantToReadBookRow(wantToReadBooksList: [RegisteredBook()])
+    FinishReadRowView(finishReadBooksList: [RegisteredBook()])
 }

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/FinishReadRowView.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/FinishReadRowView.swift
@@ -26,8 +26,9 @@ struct FinishReadRowView: View {
                 Spacer()
                 
                 // MARK: 다 읽은 책 상세 페이지로 이동
-                Button {
-                    
+                NavigationLink {
+                    BookRowDetailView(readingStatus: .finishRead, bookList: finishReadBooksList)
+                        .toolbarRole(.editor)
                 } label: {
                     Image(systemName: "chevron.right")
                         .font(.title3)
@@ -42,7 +43,7 @@ struct FinishReadRowView: View {
             ScrollView(showsIndicators: false) {
                 LazyVGrid(columns: columns) {
                     ForEach(Array(finishReadBooksList.enumerated()), id: \.offset) { index, book in
-                        // 읽고 싶은 책만 리스트로 띄우기
+                        // 다 읽은 책 리스트로 띄우기
                         BookItemView(book: book)
                     }
                 }

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/ReadingItemDetailView.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/ReadingItemDetailView.swift
@@ -1,0 +1,85 @@
+//
+//  ReadingItemDetailView.swift
+//  ReadingFrame
+//
+//  Created by 이윤지 on 3/17/24.
+//
+
+import SwiftUI
+
+/// 읽고 있는 책 상세 페이지의 리스트에 들어갈 아이템 뷰
+struct ReadingItemDetailView: View {
+    
+    /// 읽고 있는 책 객체
+    @Bindable var book: RegisteredBook
+    
+    var body: some View {
+        ZStack {
+            NavigationLink {
+                ReadingNote().toolbarRole(.editor)
+            } label: {
+                EmptyView()
+            }
+            .frame(width: 0, height: 0)
+            .hidden()
+            
+            VStack(spacing: 0) {
+                HStack(spacing: 0) {
+                    LoadableBookImage(bookCover: book.book.cover)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                        .frame(width: 80, height: 120)
+                        .padding(.trailing, 10)
+                    
+                    VStack(alignment: .leading, spacing: 0) {
+                        HStack {
+                            // MARK: 배지
+                            Badge_Info(
+                                bookType: book.bookType,
+                                category: book.book.categoryName,
+                                isMine: book.isMine
+                            )
+                            
+                            Spacer()
+                            
+                            // MARK: Menu
+                            Menu {
+                                
+                            } label: {
+                                Image(systemName: "ellipsis")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.black0)
+                            }
+                        }
+                        
+                        // MARK: 책 이름
+                        Text("\(book.book.title)")
+                            .font(.headline)
+                            .foregroundStyle(.black0)
+                            .padding(.top, 10)
+                        
+                        // MARK: 저자
+                        Text("\(book.book.author)")
+                            .font(.footnote)
+                            .foregroundStyle(.black0)
+                            .padding(.top, 3)
+                        
+                        // MARK: 진행률
+                        ReadingPercentBar(book: book)
+                            .frame(height: 55)
+                    }
+                }
+                
+                // MARK: Line
+                Rectangle()
+                    .foregroundStyle(.grey2)
+                    .frame(height: 1)
+                    .padding(.top, 16)
+            }
+            .padding(.top, 16)
+        }
+    }
+}
+
+#Preview {
+    ReadingItemDetailView(book: RegisteredBook())
+}

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/ReadingItemView.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/ReadingItemView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 /// 홈 화면의 읽고 있는 책 리스트에 들어가는 개별 뷰
-struct MainPageReadingBookItem: View {
+struct ReadingItemView: View {
     /// 읽고 싶은 책 객체
     @Bindable var book: RegisteredBook
     
@@ -171,5 +171,5 @@ struct MainPageReadingBookItem: View {
 }
 
 #Preview {
-    MainPageReadingBookItem(book: RegisteredBook())
+    ReadingItemView(book: RegisteredBook())
 }

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/ReadingItemView.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/ReadingItemView.swift
@@ -55,7 +55,9 @@ struct ReadingItemView: View {
                 .padding(.top, 2)
             
             // MARK: 막대 그래프 및 퍼센트
-            ReadingPercentBar(book: book, width: 300)
+            ReadingPercentBar(book: book)
+                .padding([.leading, .trailing], 45)
+                .frame(height: 55)
             
             HStack(spacing: 10) {
                 // MARK: 책갈피 버튼

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/ReadingLabel.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/ReadingLabel.swift
@@ -17,6 +17,7 @@ struct ReadingLabel: View {
     
     var body: some View {
         Label(label, systemImage: image)
+            .font(.footnote)
             .foregroundStyle(.black0)
             .padding(EdgeInsets(top: 6, leading: 14.5, bottom: 6, trailing: 14.5))
             .background(.white)

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/ReadingRowView.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/ReadingRowView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 /// 홈 화면의 읽고 있는 책 리스트
-struct MainPageReadingBookRow: View {
+struct ReadingRowView: View {
     
     /// 읽고 있는 책 리스트
     var readingBooksList: [RegisteredBook]
@@ -49,7 +49,7 @@ struct MainPageReadingBookRow: View {
             TabView(selection: $selectedPageIndex) {
                 
                 ForEach(Array(items.prefix(10).enumerated()), id: \.offset) { index, book in
-                    MainPageReadingBookItem(book: book) // 책 뷰 띄우기
+                    ReadingItemView(book: book) // 책 뷰 띄우기
                         .tag(index)
                 }
             }
@@ -74,5 +74,5 @@ func setTabViewIndicator() {
 }
 
 #Preview {
-    MainPageReadingBookRow(readingBooksList: [RegisteredBook()])
+    ReadingRowView(readingBooksList: [RegisteredBook()])
 }

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/ReadingRowView.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/ReadingRowView.swift
@@ -33,8 +33,9 @@ struct ReadingRowView: View {
             Spacer()
             
             // MARK: 읽고 있는 책 상세 페이지로 이동
-            Button {
-                
+            NavigationLink {
+                BookRowDetailView(readingStatus: .reading, bookList: readingBooksList)
+                    .toolbarRole(.editor)
             } label: {
                 Image(systemName: "chevron.right")
                     .font(.title3)

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/WantToReadRowView.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/WantToReadRowView.swift
@@ -26,8 +26,9 @@ struct WantToReadRowView: View {
                 Spacer()
                 
                 // MARK: 읽고 싶은 책 상세 페이지로 이동
-                Button {
-                    
+                NavigationLink {
+                    BookRowDetailView(readingStatus: .wantToRead, bookList: wantToReadBooksList)
+                        .toolbarRole(.editor)
                 } label: {
                     Image(systemName: "chevron.right")
                         .font(.title3)

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/WantToReadRowView.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/WantToReadRowView.swift
@@ -1,31 +1,31 @@
 //
-//  FinishReadBookRow.swift
+//  MainPageBookRow.swift
 //  ReadingFrame
 //
-//  Created by 이윤지 on 2/27/24.
+//  Created by 이윤지 on 2/14/24.
 //
 
 import SwiftUI
 
-/// 홈 화면의 다 읽은 책 리스트
-struct MainPageFinishReadBookRow: View {
+/// 홈 화면의 읽고 싶은 책 리스트
+struct WantToReadRowView: View {
     
-    /// 다 읽은 책 리스트
-    var finishReadBooksList: [RegisteredBook]
+    /// 읽고 싶은 책 리스트
+    var wantToReadBooksList: [RegisteredBook]
     
-    /// 그리드 아이템
-    var columns: [GridItem] = Array(repeating: .init(.flexible()), count: 2)
+    /// 읽고 싶은 책 총 개수
+    //var totalWantToReadBooksCount: Int = 0
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
-                Text("다 읽은 책 \(finishReadBooksList.count)")
+                Text("읽고 싶은 책 \(wantToReadBooksList.count)")
                     .font(.thirdTitle)
                     .foregroundStyle(.black0)
                 
                 Spacer()
                 
-                // MARK: 다 읽은 책 상세 페이지로 이동
+                // MARK: 읽고 싶은 책 상세 페이지로 이동
                 Button {
                     
                 } label: {
@@ -39,21 +39,21 @@ struct MainPageFinishReadBookRow: View {
             .padding(.bottom, 16)
             
             // 세로 스크롤 뷰
-            ScrollView(showsIndicators: false) {
-                LazyVGrid(columns: columns) {
-                    ForEach(Array(finishReadBooksList.enumerated()), id: \.offset) { index, book in
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack {
+                    ForEach(Array(wantToReadBooksList.prefix(10)), id: \.id) { book in
                         // 읽고 싶은 책만 리스트로 띄우기
-                        MainPageBookItem(book: book)
+                        BookItemView(book: book)
                     }
                 }
                 .padding(.leading, 16)
                 .padding(.trailing, 4)
             }
         }
-        .padding(.bottom, 55)
+        .padding(.bottom, 35)
     }
 }
 
 #Preview {
-    MainPageFinishReadBookRow(finishReadBooksList: [RegisteredBook()])
+    WantToReadRowView(wantToReadBooksList: [RegisteredBook()])
 }

--- a/ReadingFrame/ReadingFrame/MainPage/Views/MainPage.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Views/MainPage.swift
@@ -38,7 +38,7 @@ struct MainPage: View {
         VStack(alignment: .leading, spacing: 0) {
             // 등록된 책이 있다면
             if (readingBooksList.count >= 1) {
-                MainPageReadingBookRow(readingBooksList: readingBooksList)
+                ReadingRowView(readingBooksList: readingBooksList)
             }
             // 등록된 책이 없다면
             else {
@@ -87,7 +87,7 @@ struct MainPage: View {
         VStack(alignment: .leading, spacing: 0) {
             // 등록된 책이 있다면
             if (wantToReadBooksList.count >= 1) {
-                MainPageWantToReadBookRow(wantToReadBooksList: wantToReadBooksList)
+                WantToReadRowView(wantToReadBooksList: wantToReadBooksList)
             }
             // 등록된 책이 없다면
             else {
@@ -104,7 +104,7 @@ struct MainPage: View {
         VStack(alignment: .leading, spacing: 0) {
             // 등록된 책이 있다면
             if (finishReadBooksList.count >= 1) {
-                MainPageFinishReadBookRow(finishReadBooksList: finishReadBooksList)
+                FinishReadRowView(finishReadBooksList: finishReadBooksList)
             }
             // 등록된 책이 없다면
             else {


### PR DESCRIPTION
**홈 화면의 책 상세 화면 리스트**
- 현재 각 리스트만 띄움
- 리스트 아이템 스와이프해서 책 삭제 가능(해당 화면에서만 반영됨)
- 추후 api를 연결하면, 홈 화면에서 리스트 데이터를 끌어오지 않을 예정
- 리스트 아이템을 스와이프할 때, 휴지통 아이콘으로 변경 못함 이슈 존재
- 추후 ...버튼 클릭 이벤트 구현 예정

**독서 진행률 막대바**
- 기존: 입력한 width로 너비 고정
- 변경: 화면의 해상도 너비에 맞게 막대바가 늘어나도록 변경

파일 이름 변경
- MainPage내의 Helper에 있는 파일들 이름 변경
- 파일명이 너무 길어, 가독성을 위해 변경함