### PR TITLE
Feat: 홈 화면의 책 상세 리스트 화면 구현 완료

### DIFF
--- a/ReadingFrame/ReadingFrame.xcodeproj/project.pbxproj
+++ b/ReadingFrame/ReadingFrame.xcodeproj/project.pbxproj
@@ -54,7 +54,7 @@
 		E7A0DD2C2B7B52A7006004B5 /* Fonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A0DD2B2B7B52A7006004B5 /* Fonts.swift */; };
 		E7A0DD2E2B7B617E006004B5 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A0DD2D2B7B617E006004B5 /* SearchView.swift */; };
 		E7A0DD302B7B6B5B006004B5 /* HomeSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A0DD2F2B7B6B5B006004B5 /* HomeSegmentedControl.swift */; };
-		E7F6D81C2BA6D8C000181586 /* ReadingItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F6D81B2BA6D8C000181586 /* ReadingItemDetailView.swift */; };
+		E7F6D81C2BA6D8C000181586 /* BookItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F6D81B2BA6D8C000181586 /* BookItemDetailView.swift */; };
 		E7F6D81E2BA6D92E00181586 /* BookRowDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F6D81D2BA6D92E00181586 /* BookRowDetailView.swift */; };
 /* End PBXBuildFile section */
 
@@ -109,7 +109,7 @@
 		E7A0DD2B2B7B52A7006004B5 /* Fonts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fonts.swift; sourceTree = "<group>"; };
 		E7A0DD2D2B7B617E006004B5 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		E7A0DD2F2B7B6B5B006004B5 /* HomeSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSegmentedControl.swift; sourceTree = "<group>"; };
-		E7F6D81B2BA6D8C000181586 /* ReadingItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingItemDetailView.swift; sourceTree = "<group>"; };
+		E7F6D81B2BA6D8C000181586 /* BookItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookItemDetailView.swift; sourceTree = "<group>"; };
 		E7F6D81D2BA6D92E00181586 /* BookRowDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookRowDetailView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -357,7 +357,7 @@
 				E716315E2B7C982600BCD302 /* BookItemView.swift */,
 				E71631602B7CD08B00BCD302 /* WantToReadRowView.swift */,
 				E751B56D2B8E0D3100880123 /* FinishReadRowView.swift */,
-				E7F6D81B2BA6D8C000181586 /* ReadingItemDetailView.swift */,
+				E7F6D81B2BA6D8C000181586 /* BookItemDetailView.swift */,
 				E7F6D81D2BA6D92E00181586 /* BookRowDetailView.swift */,
 				E702A9AB2B85FB2F0081F65D /* ReadingLabel.swift */,
 				E702A9AF2B86219C0081F65D /* PageIndicator.swift */,
@@ -474,7 +474,7 @@
 				C5CEA8922B8A5CCA007A89A2 /* WrapLayout.swift in Sources */,
 				C518A8AB2B8132F800EBD1A8 /* Review.swift in Sources */,
 				E7A0DD2C2B7B52A7006004B5 /* Fonts.swift in Sources */,
-				E7F6D81C2BA6D8C000181586 /* ReadingItemDetailView.swift in Sources */,
+				E7F6D81C2BA6D8C000181586 /* BookItemDetailView.swift in Sources */,
 				C58F57192B8D001F004085A5 /* CommentReactionView.swift in Sources */,
 				E702A9B42B864D330081F65D /* ReadingNote.swift in Sources */,
 				E7A0DD302B7B6B5B006004B5 /* HomeSegmentedControl.swift in Sources */,

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/BookItemDetailView.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/BookItemDetailView.swift
@@ -7,8 +7,8 @@
 
 import SwiftUI
 
-/// 읽고 있는 책 상세 페이지의 리스트에 들어갈 아이템 뷰
-struct ReadingItemDetailView: View {
+/// 모든 책 상세 페이지의 리스트에 들어갈 아이템 뷰
+struct BookItemDetailView: View {
     
     /// 책 객체
     @Bindable var book: RegisteredBook
@@ -288,5 +288,5 @@ struct ReadingItemDetailView: View {
 }
 
 #Preview {
-    ReadingItemDetailView(book: RegisteredBook(), readingStatus: .reading)
+    BookItemDetailView(book: RegisteredBook(), readingStatus: .reading)
 }

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/BookRowDetailView.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/BookRowDetailView.swift
@@ -80,7 +80,7 @@ struct BookRowDetailView: View {
                 if (readingStatus == .reading) {
                     ForEach(notHideBookList, id: \.id) { book in
                         // 독서 상태가 안 바뀐 것만 리스트로 띄우기
-                        ReadingItemDetailView(book: book, readingStatus: readingStatus)
+                        BookItemDetailView(book: book, readingStatus: readingStatus)
                             .swipeActions(edge: .trailing) {
                                 Button(role: .destructive) {
                                     if let tempIndex = bookList.firstIndex(where: { $0.id == book.id }) {
@@ -100,7 +100,7 @@ struct BookRowDetailView: View {
                     ForEach(Array(bookList.enumerated()), id: \.offset) { index, book in
                         // 독서 상태가 안 바뀐 것만 리스트로 띄우기
                         if (book.book.readingStatus == readingStatus) {
-                            ReadingItemDetailView(book: book, readingStatus: readingStatus)
+                            BookItemDetailView(book: book, readingStatus: readingStatus)
                                 .swipeActions(edge: .trailing) {
                                     Button(role: .destructive) {
                                         bookList.remove(at: index)
@@ -133,7 +133,7 @@ struct BookRowDetailView: View {
                     // MARK: 홈 화면에서 숨긴 책 리스트
                     ForEach(hideBookList, id: \.id) { book in
                         // 숨기기 상태가 안 바뀐 것만 리스트로 띄우기
-                        ReadingItemDetailView(book: book, readingStatus: readingStatus)
+                        BookItemDetailView(book: book, readingStatus: readingStatus)
                             .swipeActions(edge: .trailing) {
                                 Button(role: .destructive) {
                                     if let tempIndex = bookList.firstIndex(where: { $0.id == book.id }) {

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/BookRowDetailView.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/BookRowDetailView.swift
@@ -51,13 +51,20 @@ struct BookRowDetailView: View {
             
             // MARK: 책 리스트
             List {
-                ForEach(bookList) { book in
+                ForEach(Array(bookList.enumerated()), id: \.offset) { index, book in
                     // 읽고 있는 책 리스트로 띄우기
                     ReadingItemDetailView(book: book)
                         .listRowSeparator(.hidden) // list 구분선 제거
                         .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                        .swipeActions(edge: .trailing) {
+                            Button(role: .destructive) {
+                                bookList.remove(at: index)
+                            } label: {
+                                Image(systemName: "trash.fill")
+                            }
+                            .tint(.red0)
+                        }
                 }
-                .onDelete(perform: delete)
             }
             .listStyle(.plain)
             .padding(.top, 15)

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/BookRowDetailView.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/BookRowDetailView.swift
@@ -11,6 +11,22 @@ import SwiftUI
 struct BookRowDetailView: View {
     var readingStatus: ReadingStatus // 독서 상태 여부
     @State var bookList: [RegisteredBook] // 각 책 리스트(추후 api연동 시 삭제될 변수)
+    @State private var selectedItem: String? // 사용자가 삭제하려고 하는 책 아이템
+    
+    // 독서 상태가 바뀌지 않은 책 리스트
+    var tempBookList: [RegisteredBook] {
+        bookList.filter { $0.book.readingStatus == readingStatus }
+    }
+    
+    // 홈 화면에서 숨긴 책 리스트
+    var hideBookList: [RegisteredBook] {
+        bookList.filter { $0.isHidden == true && $0.book.readingStatus == readingStatus}
+    }
+    
+    // 홈 화면에서 숨기지 않은 책 리스트
+    var notHideBookList: [RegisteredBook] {
+        bookList.filter { $0.isHidden == false && $0.book.readingStatus == readingStatus }
+    }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -33,41 +49,109 @@ struct BookRowDetailView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 10))
             }
             .padding([.leading, .trailing], 16)
+            .padding(.bottom, 10)
             
-            // MARK: 타이틀 및 책 개수
-            HStack {
-                title()
-                    .font(.thirdTitle)
-                    .foregroundStyle(.black0)
-                
-                Text("\(bookList.count)")
-                    .font(.thirdTitle)
-                    .foregroundStyle(.black0)
-                
-                Spacer()
-            }
-            .padding([.leading, .trailing], 16)
-            .padding(.top, 19)
-            
-            // MARK: 책 리스트
             List {
-                ForEach(Array(bookList.enumerated()), id: \.offset) { index, book in
-                    // 읽고 있는 책 리스트로 띄우기
-                    ReadingItemDetailView(book: book)
-                        .listRowSeparator(.hidden) // list 구분선 제거
-                        .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
-                        .swipeActions(edge: .trailing) {
-                            Button(role: .destructive) {
-                                bookList.remove(at: index)
-                            } label: {
-                                Image(systemName: "trash.fill")
+                // MARK: 타이틀 및 책 개수
+                HStack {
+                    title()
+                        .font(.thirdTitle)
+                        .foregroundStyle(.black0)
+                    
+                    // 읽고 있는 책이라면
+                    if (readingStatus == .reading) {
+                        Text("\(notHideBookList.count)")
+                            .font(.thirdTitle)
+                            .foregroundStyle(.black0)
+                    }
+                    // 다 읽은 책, 읽고 있는 책이라면
+                    else {
+                        Text("\(tempBookList.count)")
+                            .font(.thirdTitle)
+                            .foregroundStyle(.black0)
+                    }
+                    
+                    Spacer()
+                }
+                .padding(.top, 10)
+                
+                // MARK: 책 리스트
+                // 읽고 있는 책이라면, 숨기지 않은 책 띄우기
+                if (readingStatus == .reading) {
+                    ForEach(notHideBookList, id: \.id) { book in
+                        // 독서 상태가 안 바뀐 것만 리스트로 띄우기
+                        ReadingItemDetailView(book: book, readingStatus: readingStatus)
+                            .swipeActions(edge: .trailing) {
+                                Button(role: .destructive) {
+                                    if let tempIndex = bookList.firstIndex(where: { $0.id == book.id }) {
+                                        bookList.remove(at: tempIndex)
+                                    }
+                                } label: {
+                                    Image(systemName: "trash.fill")
+                                }
+                                .tint(.red0)
                             }
-                            .tint(.red0)
+                            .listRowSeparator(.hidden) // list 구분선 제거
+                            .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                    }
+                }
+                // 다 읽은 책, 읽고 싶은 책이라면
+                else {
+                    ForEach(Array(bookList.enumerated()), id: \.offset) { index, book in
+                        // 독서 상태가 안 바뀐 것만 리스트로 띄우기
+                        if (book.book.readingStatus == readingStatus) {
+                            ReadingItemDetailView(book: book, readingStatus: readingStatus)
+                                .swipeActions(edge: .trailing) {
+                                    Button(role: .destructive) {
+                                        bookList.remove(at: index)
+                                    } label: {
+                                        Image(systemName: "trash.fill")
+                                    }
+                                    .tint(.red0)
+                                }
                         }
+                    }
+                    .listRowSeparator(.hidden) // list 구분선 제거
+                    .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                }
+                
+                // MARK: 홈 화면에서 숨긴 책 및 책 개수
+                if (!hideBookList.isEmpty && readingStatus == .reading) {
+                    HStack {
+                        Text("홈 화면에서 숨긴 책")
+                            .font(.thirdTitle)
+                            .foregroundStyle(.black0)
+                        
+                        Text("\(hideBookList.count)")
+                            .font(.thirdTitle)
+                            .foregroundStyle(.black0)
+                        
+                        Spacer()
+                    }
+                    .padding(.top, 40)
+                    
+                    // MARK: 홈 화면에서 숨긴 책 리스트
+                    ForEach(hideBookList, id: \.id) { book in
+                        // 숨기기 상태가 안 바뀐 것만 리스트로 띄우기
+                        ReadingItemDetailView(book: book, readingStatus: readingStatus)
+                            .swipeActions(edge: .trailing) {
+                                Button(role: .destructive) {
+                                    if let tempIndex = bookList.firstIndex(where: { $0.id == book.id }) {
+                                        bookList.remove(at: tempIndex)
+                                    }
+                                } label: {
+                                    Image(systemName: "trash.fill")
+                                }
+                                .tint(.red0)
+                            }
+                    }
+                    .listRowSeparator(.hidden) // list 구분선 제거
+                    .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
                 }
             }
             .listStyle(.plain)
-            .padding(.top, 15)
+            .listRowSeparator(.hidden) // list 구분선 제거
+            .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
         }
         // MARK: 네비게이션 타이틀 바
         .navigationTitle(title())
@@ -88,8 +172,10 @@ struct BookRowDetailView: View {
     }
     
     // 리스트 책 아이템 삭제 함수
-    func delete(indexSet: IndexSet) {
-        bookList.remove(atOffsets: indexSet)
+    func deleteBookItem(indexSet: IndexSet) {
+        guard let index = indexSet.first else { return }
+        bookList.remove(at: index)
+        selectedItem = nil
     }
 }
 

--- a/ReadingFrame/ReadingFrame/MainPage/Helpers/ReadingItemDetailView.swift
+++ b/ReadingFrame/ReadingFrame/MainPage/Helpers/ReadingItemDetailView.swift
@@ -10,39 +10,133 @@ import SwiftUI
 /// 읽고 있는 책 상세 페이지의 리스트에 들어갈 아이템 뷰
 struct ReadingItemDetailView: View {
     
-    /// 읽고 있는 책 객체
+    /// 책 객체
     @Bindable var book: RegisteredBook
     
+    /// 독서 상태 여부
+    var readingStatus: ReadingStatus
+    
+    /// 읽고 있는 책 관련 변수
+    /// 다 읽음 Popup 띄움 여부 확인
+    @State private var isShowFinishReadAlert = false
+    
+    /// 홈 화면에서 숨기기 Popup 띄움 여부 확인
+    @State private var isShowHideBookAlert = false
+    
+    /// 소장 Popup 띄움 여부 확인
+    @State private var isShowMineTrueAlert = false
+    
+    /// 미소장 Popup 띄움 여부 확인
+    @State private var isShowMineFalseAlert = false
+    
+    /// 읽고 싶은 책 관련 변수
+    /// sheet가 띄워져 있는지 확인하는 변수
+    @State var isRegisterSheetAppear: Bool = false
+    
+    /// sheet를 띄우기 위한 기본 값
+    @State var sheetReadingStatus: ReadingStatus = .reading
+    
     var body: some View {
-        ZStack {
-            NavigationLink {
-                ReadingNote().toolbarRole(.editor)
-            } label: {
-                EmptyView()
-            }
-            .frame(width: 0, height: 0)
-            .hidden()
-            
-            VStack(spacing: 0) {
-                HStack(spacing: 0) {
-                    LoadableBookImage(bookCover: book.book.cover)
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
-                        .frame(width: 80, height: 120)
-                        .padding(.trailing, 10)
-                    
-                    VStack(alignment: .leading, spacing: 0) {
-                        HStack {
-                            // MARK: 배지
-                            Badge_Info(
-                                bookType: book.bookType,
-                                category: book.book.categoryName,
-                                isMine: book.isMine
-                            )
-                            
-                            Spacer()
-                            
-                            // MARK: Menu
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 0) {
+                // MARK: - 책 표지
+                LoadableBookImage(bookCover: book.book.cover)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .frame(width: 80, height: 120)
+                    .padding(.trailing, 10)
+                
+                VStack(alignment: .leading, spacing: 0) {
+                    HStack {
+                        // MARK: - 배지
+                        Badge_Info(
+                            bookType: book.bookType,
+                            category: book.book.categoryName,
+                            isMine: book.isMine
+                        )
+                        
+                        Spacer()
+                        
+                        // MARK: - Menu
+                        // MARK: - 읽고 싶은 책인 경우
+                        if (readingStatus == .wantToRead) {
                             Menu {
+                                // MARK: 읽는 중 버튼
+                                // 버튼 클릭시 등록 sheet 띄우기
+                                Button {
+                                    isRegisterSheetAppear.toggle()
+                                    sheetReadingStatus = .reading
+                                } label: {
+                                    Label("읽는 중", systemImage: "book")
+                                }
+                                // MARK: 다 읽음 버튼
+                                Button {
+                                    isRegisterSheetAppear.toggle()
+                                    sheetReadingStatus = .finishRead
+                                } label: {
+                                    Label("다 읽음", systemImage: "book.closed")
+                                }
+                            } label: {
+                                Image(systemName: "ellipsis")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.black0)
+                            }
+                        }
+                        // MARK: - 읽고 있는 책인 경우
+                        else if (readingStatus == .reading) {
+                            Menu {
+                                // MARK: 다 읽음 버튼
+                                Button {
+                                    isShowFinishReadAlert.toggle()
+                                } label: {
+                                    Label("다 읽음", systemImage: "book.closed")
+                                }
+                                
+                                // MARK: 정보 버튼
+                                NavigationLink {
+                                    // 책 정보 화면으로 이동
+                                    BookInfo(modelData: BookInfoModel(book: book.book as! InitialBook))
+                                        .toolbarRole(.editor) // back 텍스트 표시X
+                                        .toolbar(.hidden, for: .tabBar) // toolbar 숨기기
+                                } label: {
+                                    Label("정보", systemImage: "info.circle")
+                                }
+                                
+                                // MARK: 리뷰 남기기 or 확인하기 버튼
+                                Button {
+                                    // TODO: 리뷰 남기기 화면 연결
+                                } label: {
+                                    Label("리뷰 남기기", systemImage: "bubble")
+                                }
+                                
+                                // MARK: 소장 버튼
+                                Button {
+                                    // 소장한 책인 경우
+                                    if (book.isMine) {
+                                        isShowMineTrueAlert.toggle()
+                                    }
+                                    // 소장하지 않은 책인 경우
+                                    else {
+                                        isShowMineFalseAlert.toggle()
+                                    }
+                                } label: {
+                                    Label("소장", systemImage: "square.and.arrow.down")
+                                }
+                                
+                                // MARK: 꺼내기 or 홈 화면에서 숨기기 버튼
+                                if (book.isHidden) {
+                                    Button {
+                                        book.isHidden = false
+                                    } label: {
+                                        Label("꺼내기", systemImage: "tray.and.arrow.up")
+                                    }
+                                }
+                                else {
+                                    Button {
+                                        isShowHideBookAlert.toggle()
+                                    } label: {
+                                        Label("홈 화면에서 숨기기", systemImage: "eye.slash")
+                                    }
+                                }
                                 
                             } label: {
                                 Image(systemName: "ellipsis")
@@ -50,36 +144,149 @@ struct ReadingItemDetailView: View {
                                     .foregroundStyle(.black0)
                             }
                         }
+                        // MARK: - 다 읽은 책인 경우
+                        else {
+                            Menu {
+                                // MARK: 정보 버튼
+                                NavigationLink {
+                                    // 책 정보 화면으로 이동
+                                    BookInfo(modelData: BookInfoModel(book: book.book as! InitialBook))
+                                        .toolbarRole(.editor) // back 텍스트 표시X
+                                        .toolbar(.hidden, for: .tabBar) // toolbar 숨기기
+                                } label: {
+                                    Label("정보", systemImage: "info.circle")
+                                }
+                                
+                                // MARK: 소장 버튼
+                                Button {
+                                    // 소장한 책인 경우
+                                    if (book.isMine) {
+                                        isShowMineTrueAlert.toggle()
+                                    }
+                                    // 소장하지 않은 책인 경우
+                                    else {
+                                        isShowMineFalseAlert.toggle()
+                                    }
+                                } label: {
+                                    Label("소장", systemImage: "square.and.arrow.down")
+                                }
+                                
+                                // MARK: 리뷰 남기기 or 확인하기 버튼
+                                Button {
+                                    // TODO: 리뷰 남기기 화면 연결
+                                } label: {
+                                    Label("리뷰 남기기", systemImage: "bubble")
+                                }
+                                
+                            } label: {
+                                Image(systemName: "ellipsis")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.black0)
+                            }
+                        }
+                    }
                         
-                        // MARK: 책 이름
-                        Text("\(book.book.title)")
-                            .font(.headline)
-                            .foregroundStyle(.black0)
-                            .padding(.top, 10)
-                        
-                        // MARK: 저자
-                        Text("\(book.book.author)")
-                            .font(.footnote)
-                            .foregroundStyle(.black0)
-                            .padding(.top, 3)
-                        
-                        // MARK: 진행률
+                    // MARK: 책 이름
+                    Text("\(book.book.title)")
+                        .font(.headline)
+                        .foregroundStyle(.black0)
+                        .padding(.top, 10)
+                    
+                    // MARK: 저자
+                    Text("\(book.book.author)")
+                        .font(.footnote)
+                        .foregroundStyle(.black0)
+                        .padding(.top, 3)
+                    
+                    // MARK: 진행률
+                    if (readingStatus == .reading) {
+                        // 읽고 있는 책일 때만 진행률 띄우기
                         ReadingPercentBar(book: book)
                             .frame(height: 55)
                     }
                 }
-                
-                // MARK: Line
-                Rectangle()
-                    .foregroundStyle(.grey2)
-                    .frame(height: 1)
-                    .padding(.top, 16)
+                // MARK: - 책 등록 sheet
+                .sheet(isPresented: $isRegisterSheetAppear) {
+                    RegisterBook(book: book.book as! InitialBook,
+                                 readingStatus: $sheetReadingStatus,
+                                 isSheetAppear: $isRegisterSheetAppear)
+                }
+                // MARK: 다 읽음 버튼 클릭 시 나타나는 Alert
+                .alert(
+                    "책을 다 읽으셨나요?",
+                    isPresented: $isShowFinishReadAlert
+                ) {
+                    Button("확인") {
+                        book.book.readingStatus = .finishRead
+                    }
+                    Button("취소", role: .cancel) { }
+                } message: {
+                    Text("다읽은 책으로 표시됩니다.")
+                }
+                // MARK: 소장 버튼 클릭 시 팝업 띄우기(소장한 책인 경우)
+                .alert(
+                    "이미 소장된 책입니다",
+                    isPresented: $isShowMineTrueAlert
+                ) {
+                    Button("확인") { }
+                }
+                // MARK: 소장 버튼 클릭 시 팝업 띄우기(소장하지 않은 책인 경우)
+                .alert(
+                    "책을 소장했습니다",
+                    isPresented: $isShowMineFalseAlert
+                ) {
+                    Button("확인") {
+                        book.isMine = true
+                    }
+                }
+                // MARK: 홈 화면에서 숨기기 버튼 클릭 시 팝업 띄우기
+                .alert(
+                    "읽는 중인 책을 숨깁니다",
+                    isPresented: $isShowHideBookAlert
+                ) {
+                    Button("확인") {
+                        book.isHidden = true
+                    }
+                    Button("취소", role: .cancel) { }
+                } message: {
+                    Text("읽는 중인 책 전체보기에서\n확인하실 수 있습니다.")
+                }
             }
-            .padding(.top, 16)
+                
+            // MARK: Line
+            Rectangle()
+                .foregroundStyle(.grey2)
+                .frame(height: 1)
+                .padding(.top, 16)
+        }
+        .padding(.top, 16)
+        .background(
+            // 책 아이템 클릭 시, 각 화면으로 이동하기
+            NavigationLink("", destination: destinationView(book: book))
+                .opacity(0)
+        )
+    }
+    
+    // 아이템 클릭 시 이동하는 화면 함수
+    @ViewBuilder
+    func destinationView(book: RegisteredBook) -> some View {
+        // 읽고 싶은 책이라면
+        if (readingStatus == .wantToRead) {
+            // 책 정보 화면으로 이동
+            BookInfo(modelData: BookInfoModel(book: book.book as! InitialBook))
+                .toolbarRole(.editor) // back 텍스트 표시X
+                .toolbar(.hidden, for: .tabBar) // toolbar 숨기기
+        }
+        // 읽는 중, 다 읽은 책이라면
+        else {
+            // TODO: 독서노트 화면으로 이동
+            ReadingNote()
+                .toolbarRole(.editor) // back 텍스트 표시X
+                .toolbar(.hidden, for: .tabBar) // toolbar 숨기기
         }
     }
 }
 
 #Preview {
-    ReadingItemDetailView(book: RegisteredBook())
+    ReadingItemDetailView(book: RegisteredBook(), readingStatus: .reading)
 }


### PR DESCRIPTION
- 홈 화면의 책 상세 리스트 화면 구현
1. 아이템을 스와이프하면 휴지통이 띄워지도록 로직 변경
2. 모든 책: 아이템 클릭 시, 각 화면으로 이동
3. 읽고 있는 책: **리뷰 남기기 버튼 제외** 클릭 이벤트 구현 완료, 홈 화면에서 숨긴 책 리스트 띄우기 완료
4. 읽고 싶은 책: 읽는중/다읽음 클릭 이벤트 구현 완료
5. 다 읽은 책: **리뷰 남기기 버튼 제외** 클릭 이벤트 구현 완료

- 파일 이름 변경
홈 화면에 있는 모든 책의 상세 리스트에서 사용하는 아이템 뷰
ReadingItemDetailView -> BookItemDetailView로 파일 이름 변경